### PR TITLE
Cosmetic fixes

### DIFF
--- a/packages/ppf-contracts/contracts/PPF.sol
+++ b/packages/ppf-contracts/contracts/PPF.sol
@@ -111,6 +111,8 @@ contract PPF is IFeed {
     * @param _operator Public key allowed to sign messages to update the pricefeed
     */
     function setOperator(address _operator) external {
+        // Allow the current operator to change the operator to avoid having to hassle the
+        // operatorOwner in cases where a node just wants to rotate its public key
         require(msg.sender == operator || msg.sender == operatorOwner);
         _setOperator(_operator);
     }

--- a/packages/ppf-contracts/contracts/open-zeppelin/ECRecovery.sol
+++ b/packages/ppf-contracts/contracts/open-zeppelin/ECRecovery.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.4.24;
 
-// Using ECRecovery at OZ's commit ad12381549c4c0711c2f3310e9fb1f65d51c299c + added personalRecover function
+// Using ECRecovery from open-zeppelin@ad12381549c4c0711c2f3310e9fb1f65d51c299c + added personalRecover function
+// See https://github.com/OpenZeppelin/openzeppelin-solidity/blob/ad12381549c4c0711c2f3310e9fb1f65d51c299c/contracts/ECRecovery.sol
 
 library ECRecovery {
   /**


### PR DESCRIPTION
Small cosmetic changes:

- 0f21df0: fix extra whitespace
- 661dc9a: documentation improvements for linking to open-zeppelin and why `operator` is allowed to change itself