### PR TITLE
Chore: Ping Truffle version to 4.1.14

### DIFF
--- a/packages/ppf-contracts/package.json
+++ b/packages/ppf-contracts/package.json
@@ -27,6 +27,6 @@
     "@aragon/ppf.js": "^1.0.0",
     "@aragon/test-helpers": "^1.0.1",
     "solidity-coverage": "^0.5.4",
-    "truffle": "^4.1.11"
+    "truffle": "4.1.14"
   }
 }


### PR DESCRIPTION
If not pinged, NPM will install 4.1.15 which carries solc 0.4.25 with it. Since there are some contracts relying on solc 0.4.24, it causes a compilation error.