### PR TITLE
Contracts: Use time helpers for `block.timestamp`

### DIFF
--- a/packages/ppf-contracts/contracts/PPF.sol
+++ b/packages/ppf-contracts/contracts/PPF.sol
@@ -2,9 +2,10 @@ pragma solidity 0.4.24;
 
 import "./IFeed.sol";
 import "./open-zeppelin/ECRecovery.sol";
+import "@aragon/os/contracts/common/TimeHelpers.sol";
 
 
-contract PPF is IFeed {
+contract PPF is IFeed, TimeHelpers {
     using ECRecovery for bytes32;
 
     struct Price {
@@ -45,7 +46,7 @@ contract PPF is IFeed {
         bytes32 pair = pairId(base, quote);
 
         // Ensure it is more recent than the current value (implicit check for > 0) and not a future date
-        require(when > feed[pair].when && when <= block.timestamp);
+        require(when > feed[pair].when && when <= getTimestamp());
         require(xrt > 0); // Make sure xrt is not 0, as the math would break (Dividing by 0 sucks big time)
         require(base != quote); // Assumption that currency units are fungible and xrt should always be 1
 

--- a/packages/ppf-contracts/package.json
+++ b/packages/ppf-contracts/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/aragon/ppf#readme",
   "devDependencies": {
+    "@aragon/os": "^4.0.1",
     "@aragon/ppf.js": "^1.0.0",
     "@aragon/test-helpers": "^1.0.1",
     "solidity-coverage": "^0.5.4",

--- a/packages/ppf-contracts/package.json
+++ b/packages/ppf-contracts/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/aragon/ppf#readme",
   "devDependencies": {
-    "@aragon/os": "^4.0.1",
+    "@aragon/os": "4.2.0",
     "@aragon/ppf.js": "^1.0.0",
     "@aragon/test-helpers": "^1.0.1",
     "solidity-coverage": "^0.5.4",


### PR DESCRIPTION
I'm using `TimeHelpers` from `@aragon/os` to follow the way we are working with timestamps and block numbers which simplifies things a lot if we need to mock PPF contracts for testing purposes