### PR TITLE
Chore: Ping Web3 libraries to version 1.0.0-beta.34

### DIFF
--- a/packages/ppf.js/package.json
+++ b/packages/ppf.js/package.json
@@ -21,7 +21,7 @@
     "@aragon/ppf-contracts": "^1.0.0",
     "bignumber.js": "^2.0.7",
     "eth-sig-util": "^1.4.2",
-    "web3-eth-abi": "^1.0.0-beta.34",
-    "web3-utils": "^1.0.0-beta.34"
+    "web3-eth-abi": "1.0.0-beta.34",
+    "web3-utils": "1.0.0-beta.34"
   }
 }


### PR DESCRIPTION
Pinging web3 libraries to avoid NPM from installing latest beta versions which do not follow the interface we are using.