### PR TITLE
Chore: Compile contracts before running tests

### DIFF
--- a/packages/ppf-contracts/package.json
+++ b/packages/ppf-contracts/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "compile": "truffle compile --all",
-    "test": "truffle test",
+    "test": "npm run compile && truffle test",
     "coverage": "solidity-coverage",
     "abi:extract": "truffle-extract --output abi/ --keys abi",
     "prepublishOnly": "npm run compile && npm run abi:extract -- --no-compile"


### PR DESCRIPTION
Contracts tests are using ppf.js which is relying on contracts artifacts, but tests are loaded before contracts are compiled, I'm forcing a compilation first before running the tests. This fixes the CI as well.