### PR TITLE
Add rate precision function to IFeed

### DIFF
--- a/lerna-debug.log
+++ b/lerna-debug.log
@@ -28,7 +28,7 @@
 13 error npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
 13 error
 13 error npm ERR! A complete log of this run can be found in:
-13 error npm ERR!     /Users/facu/.npm/_logs/2019-07-02T23_11_57_493Z-debug.log
+13 error npm ERR!     /Users/facu/.npm/_logs/2019-07-02T23_22_39_064Z-debug.log
 13 error npm ERR! code ELIFECYCLE
 13 error npm ERR! errno 1
 13 error npm ERR! @aragon/ppf-contracts@1.1.0 test: `npm run compile && truffle test`
@@ -38,7 +38,7 @@
 13 error npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
 13 error
 13 error npm ERR! A complete log of this run can be found in:
-13 error npm ERR!     /Users/facu/.npm/_logs/2019-07-02T23_11_57_549Z-debug.log
+13 error npm ERR!     /Users/facu/.npm/_logs/2019-07-02T23_22_39_085Z-debug.log
 13 error
 13 error
 13 error > @aragon/ppf-contracts@1.1.0 test /Users/facu/Documents/work/aragon/dev/ppf/packages/ppf-contracts
@@ -57,10 +57,10 @@
 13 error Compiling @aragon/os/contracts/common/TimeHelpers.sol...
 13 error Compiling @aragon/os/contracts/common/Uint256Helpers.sol...
 13 error
-13 error /Users/facu/Documents/work/aragon/dev/ppf/packages/ppf-contracts/contracts/PPFFactory.sol:9:19: TypeError: Trying to create an instance of an abstract contract.
-13 error         PPF ppf = new PPF(operator, operatorOwner);
-13 error                   ^-----^
-13 error /Users/facu/Documents/work/aragon/dev/ppf/packages/ppf-contracts/contracts/IFeed.sol:4:5: Missing implementation:
+13 error /Users/facu/Documents/work/aragon/dev/ppf/packages/ppf-contracts/contracts/PPF.sol:73:5: TypeError: Overriding function changes state mutability from "pure" to "nonpayable".
+13 error     function ratePrecision() external returns (uint256) {
+13 error     ^ (Relevant source part starts here and spans across multiple lines).
+13 error /Users/facu/Documents/work/aragon/dev/ppf/packages/ppf-contracts/contracts/IFeed.sol:4:5: Overriden function is here:
 13 error     function ratePrecision() external pure returns (uint256);
 13 error     ^-------------------------------------------------------^
 13 error [31mCompilation failed. See above.[39m

--- a/lerna-debug.log
+++ b/lerna-debug.log
@@ -1,0 +1,69 @@
+0 silly input [ 'test' ]
+1 silly flags { _: [ 'run' ],
+1 silly flags   'reject-cycles': false,
+1 silly flags   rejectCycles: false,
+1 silly flags   stream: true,
+1 silly flags   scope: '@aragon/ppf-contracts',
+1 silly flags   concurrency: 1,
+1 silly flags   script: 'test',
+1 silly flags   args: [] }
+2 verbose rootPath /Users/facu/Documents/work/aragon/dev/ppf
+3 info version 2.11.0
+4 silly existsSync /Users/facu/Documents/work/aragon/dev/ppf/VERSION
+5 info versioning independent
+6 info scope @aragon/ppf-contracts
+7 silly initialize attempt
+8 silly initialize success
+9 silly execute attempt
+10 silly runScriptInPackageStreaming [ 'test', [], '@aragon/ppf-contracts' ]
+11 silly getExecOpts { cwd: '/Users/facu/Documents/work/aragon/dev/ppf/packages/ppf-contracts' }
+12 error execute callback with error
+13 error Error: Command failed: npm run test
+13 error npm ERR! code ELIFECYCLE
+13 error npm ERR! errno 1
+13 error npm ERR! @aragon/ppf-contracts@1.1.0 compile: `truffle compile --all`
+13 error npm ERR! Exit status 1
+13 error npm ERR!
+13 error npm ERR! Failed at the @aragon/ppf-contracts@1.1.0 compile script.
+13 error npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
+13 error
+13 error npm ERR! A complete log of this run can be found in:
+13 error npm ERR!     /Users/facu/.npm/_logs/2019-07-02T23_11_57_493Z-debug.log
+13 error npm ERR! code ELIFECYCLE
+13 error npm ERR! errno 1
+13 error npm ERR! @aragon/ppf-contracts@1.1.0 test: `npm run compile && truffle test`
+13 error npm ERR! Exit status 1
+13 error npm ERR!
+13 error npm ERR! Failed at the @aragon/ppf-contracts@1.1.0 test script.
+13 error npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
+13 error
+13 error npm ERR! A complete log of this run can be found in:
+13 error npm ERR!     /Users/facu/.npm/_logs/2019-07-02T23_11_57_549Z-debug.log
+13 error
+13 error
+13 error > @aragon/ppf-contracts@1.1.0 test /Users/facu/Documents/work/aragon/dev/ppf/packages/ppf-contracts
+13 error > npm run compile && truffle test
+13 error
+13 error
+13 error > @aragon/ppf-contracts@1.1.0 compile /Users/facu/Documents/work/aragon/dev/ppf/packages/ppf-contracts
+13 error > truffle compile --all
+13 error
+13 error Compiling ./contracts/IFeed.sol...
+13 error Compiling ./contracts/IPPFFactory.sol...
+13 error Compiling ./contracts/PPF.sol...
+13 error Compiling ./contracts/PPFFactory.sol...
+13 error Compiling ./contracts/misc/Migrations.sol...
+13 error Compiling ./contracts/open-zeppelin/ECRecovery.sol...
+13 error Compiling @aragon/os/contracts/common/TimeHelpers.sol...
+13 error Compiling @aragon/os/contracts/common/Uint256Helpers.sol...
+13 error
+13 error /Users/facu/Documents/work/aragon/dev/ppf/packages/ppf-contracts/contracts/PPFFactory.sol:9:19: TypeError: Trying to create an instance of an abstract contract.
+13 error         PPF ppf = new PPF(operator, operatorOwner);
+13 error                   ^-----^
+13 error /Users/facu/Documents/work/aragon/dev/ppf/packages/ppf-contracts/contracts/IFeed.sol:4:5: Missing implementation:
+13 error     function ratePrecision() external pure returns (uint256);
+13 error     ^-------------------------------------------------------^
+13 error [31mCompilation failed. See above.[39m
+13 error
+13 error     at Promise.all.then.arr (/Users/facu/Documents/work/aragon/dev/ppf/node_modules/execa/index.js:236:11)
+13 error     at <anonymous>

--- a/packages/ppf-contracts/contracts/IFeed.sol
+++ b/packages/ppf-contracts/contracts/IFeed.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.18;
 
 interface IFeed {
+    function ratePrecision() external pure returns (uint256);
     function get(address base, address quote) external view returns (uint128 xrt, uint64 when);
 }

--- a/packages/ppf-contracts/contracts/PPF.sol
+++ b/packages/ppf-contracts/contracts/PPF.sol
@@ -8,8 +8,8 @@ import "@aragon/os/contracts/common/TimeHelpers.sol";
 contract PPF is IFeed, TimeHelpers {
     using ECRecovery for bytes32;
 
-    uint256 constant public ONE = 10 ** 18; // 10^18 is considered 1 in the price feed to allow for decimal calculations
     bytes32 constant public PPF_v1_ID = 0x33a8ba7202230fa1cee2aac7bac322939edc7ba0a48b0989335a5f87a5770369; // keccak256("PPF-v1");
+    uint256 constant internal ONE = 10 ** 18; // 10^18 is considered 1 in the price feed to allow for decimal calculations
 
     string private constant ERROR_BAD_SIGNATURE = "PPF_BAD_SIGNATURE";
     string private constant ERROR_BAD_RATE_TIMESTAMP = "PPF_BAD_RATE_TIMESTAMP";
@@ -65,6 +65,13 @@ contract PPF is IFeed, TimeHelpers {
     function setOperatorOwner(address _operatorOwner) external {
         require(msg.sender == operatorOwner, ERROR_CAN_NOT_SET_OPERATOR_OWNER);
         _setOperatorOwner(_operatorOwner);
+    }
+
+    /**
+    * @return The minimum rate precision used for the exchange rates
+    */
+    function ratePrecision() external pure returns (uint256) {
+        return ONE;
     }
 
     /**


### PR DESCRIPTION
**MERGE AFTER https://github.com/aragon/ppf/pull/27**

Adding a `ratePrecision` function to `IFeed` allowing price feed implementations to tell which minimum rate precision they are using for the exchange rates being provided.